### PR TITLE
[#11] main.py 이슈 - DevToolsActivePort file doesn't exist 추가 오류 해결

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ chromeOptions = ChromeOptions()
 # chromeOptions.add_argument("window-size=1920x1200") # window-size 설정
 # chromeOptions.add_experimental_option("detach", True) # 브라우저 꺼짐 방지 옵션
 chromeOptions.add_experimental_option("excludeSwitches", ["enable-logging"]) # 불필요한 에러 메시지 제거코드
-chromeOptions.add_argument("headless"); # 헤드리스 사용
+chromeOptions.add_argument("headless=old"); # 헤드리스 사용 (old로 기존 헤드리스 사용)
 chromeOptions.add_argument("disable-infobars") # 정보 표시줄 사용X
 chromeOptions.add_argument("disable-extensions"); # 확장 사용안함
 chromeOptions.add_argument("disable-popup-blocking"); #팝업 X
@@ -41,8 +41,12 @@ chromeOptions.add_argument("disable-gpu");	# gpu 비활성화
 chromeOptions.add_argument("user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.5938.149 Safari/537.36") # 사용자인척 위장
 chromeOptions.add_argument('no-sandbox')
 chromeOptions.add_argument('disable-dev-shm-usage')
-chromeOptions.add_argument('--remote-debugging-pipe') # DevToolsActivePort 에러 해결을 위해..(아마 이거 사용 안하게 하는거일걸?)
-chromeService = ChromeService(ChromeDriverManager().install()) # 크롬드라이버 자동
+chromedriverPath = ChromeDriverManager().install()
+# chromedriver 경로 확인 및 명시적으로 실행 파일 경로 지정 -> THIRD_PARTY_NOTICES.chromedriver 로 선택되는 문제 해결
+if os.path.isfile(os.path.join(os.path.dirname(chromedriverPath), "chromedriver")):
+    chromedriverPath = os.path.join(os.path.dirname(chromedriverPath), "chromedriver")
+chromeService = ChromeService(chromedriverPath) # 크롬드라이버 자동
+print(f"Installed ChromeDriver path: {chromedriverPath}")
 
 #############################################################
 # global variable setting


### PR DESCRIPTION
1. DevToolsActivePort file doesn't exist 에러 해결을 위해 chromeOptions.add_argument('--remote-debugging-pipe') 추가로 해결 했지만, crontab에서 실행 시 기본 터미널의 환경설정과 차이로 인해 동작하지 않는 점 발견.
=> 환경설정 통일(터미널 환경처럼 수정) + Xvfb 가상 디스플레이 사용(headless라도 이걸 사용해야 크롬설정이 잘 적용)
=> 추가로 headless 도 old버전과 new버전이 있으므로 old버전을 사용!
=> 환경설정, Xvfb 사용 둘 다 crontab 으로 해결 (물론 Xvfb 설치는 따로 해둬야 함)

2. 추가로 크롭 최신 버전(131)과 webdriver-manager라이브러리 최신버전(4.0.2)으로 업데이트 후 chromedriver 찾지 못하는 점 발견.
=> 파이썬 코드 내에서 해결 함.

파이썬 코드는 커밋에서 참고!! crontab은 아래를 참고!
```
# setting
SHELL=/bin/bash
HOME=/root
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/u>
DISPLAY=:99

# 디스플레이 99번으로 설정하고 Xvfb 구동! (정지 위해 따로 PID 기록)
1 11 * * * DISPLAY=:99 Xvfb :99 -ac -screen 0 1280x1024x24 & echo $! > /tmp/xvfb_pid
# 원하는 파이썬 파일 구동!
1 12 * * * python /var/www/smartstore-parser/main.py
# 가상 디스플레이 99번 Xvfb 구동 정지!
1 14 * * * kill -9 $(cat /tmp/xvfb_pid)
```